### PR TITLE
Draft: Update gencerts.sh

### DIFF
--- a/gencerts.sh
+++ b/gencerts.sh
@@ -1,12 +1,12 @@
-
 # CA key and certificate
-openssl req -new -x509 -nodes -subj '/CN=Whitelist Registry Controller Webook' -keyout ca.key -out ca.crt 
+#openssl req -new -x509 -nodes -subj '/CN=Whitelist Registry Controller Webook' -keyout ca.key -out ca.crt 
 # server key
-openssl genrsa -out server.key 2048
+#openssl genrsa -out server.key 2048
 # CSR
-openssl req -new -key server.key -subj '/CN=whitelist-registry.default.svc' -addext "subjectAltName = DNS:whitelist-registry.default.svc" -out server.csr
+openssl req -new -key server.key -subj '/CN=whitelist-registry.default.svc' -out server.csr
 # server certificate
 openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt 
+openssl x509 -req -extfile <(printf "subjectAltName=DNS:whitelist-registry.default.svc") -days 365 -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt
 
 # copy certs to app folder
 chmod 644 *.key

--- a/gencerts.sh
+++ b/gencerts.sh
@@ -4,7 +4,7 @@ openssl req -new -x509 -nodes -subj '/CN=Whitelist Registry Controller Webook' -
 # server key
 openssl genrsa -out server.key 2048
 # CSR
-openssl req -new -key server.key -subj '/CN=whitelist-registry.default.svc' -out server.csr
+openssl req -new -key server.key -subj '/CN=whitelist-registry.default.svc' -addext "subjectAltName = DNS:whitelist-registry.default.svc" -out server.csr
 # server certificate
 openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt 
 


### PR DESCRIPTION
Use SAN which is required from Go 1.15: https://jfrog.com/knowledge-base/general-what-should-i-do-if-i-get-an-x509-certificate-relies-on-legacy-common-name-field-error/