### PR TITLE
Update gencerts.sh

### DIFF
--- a/gencerts.sh
+++ b/gencerts.sh
@@ -6,7 +6,7 @@ openssl genrsa -out server.key 2048
 # CSR
 openssl req -new -key server.key -subj '/CN=whitelist-registry.default.svc' -out server.csr
 # server certificate
-openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt 
+openssl x509 -req -extfile <(printf "subjectAltName=DNS:whitelist-registry.default.svc") -days 365 -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt
 
 # copy certs to app folder
 chmod 644 *.key


### PR DESCRIPTION
Uses SubjectAlternativeName which is required by Go 15+ and otherwise would mean a connection failure to the WebHook. From https://stackoverflow.com/questions/64814173/how-do-i-use-sans-with-openssl-instead-of-common-name